### PR TITLE
feat: Add full demo mode with seeded App Store review account

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
 
   # Swift-specific checks using SwiftLint
   - repo: https://github.com/realm/SwiftLint
-    rev: 0.62.2
+    rev: 0.63.2
     hooks:
       - id: swiftlint
         name: SwiftLint
@@ -60,10 +60,11 @@ repos:
 
   # Markdown linting for documentation
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.47.0
+    rev: v0.48.0
     hooks:
       - id: markdownlint
         name: Markdown Lint
+        language_version: system
         args: ["--fix", "--config", ".markdownlint.yaml"]
         exclude: "CHANGELOG.md"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file. See [conventional commits](https://www.conventionalcommits.org/) for commit guidelines.
 
 - - -
+## Unreleased
+#### Features
+- add full demo mode with seeded App Store review account, local scenarios, and credential-free walkthrough
+
+- - -
 ## v0.23.3 - 2026-01-30
 #### Bug Fixes
 - use sheet(item:) for edit account to pass account data correctly - (6d8bba5) - Rob Lazzurs

--- a/OnCallNotify.xcodeproj/project.pbxproj
+++ b/OnCallNotify.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		A10000001ABC000000000013 /* MenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000001ABC000000000014 /* MenuView.swift */; };
 		A10000001ABC000000000015 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A10000001ABC000000000016 /* Assets.xcassets */; };
 		A10000001ABC000000000036 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000001ABC000000000037 /* NotificationService.swift */; };
+		A10000001ABC000000000040 /* EditAccountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10000001ABC000000000041 /* EditAccountView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -30,6 +31,7 @@
 		A10000001ABC000000000017 /* OnCallNotify.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = OnCallNotify.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A10000001ABC000000000018 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A10000001ABC000000000037 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
+		A10000001ABC000000000041 /* EditAccountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditAccountView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -96,6 +98,7 @@
 			children = (
 				A10000001ABC000000000012 /* SettingsView.swift */,
 				A10000001ABC000000000014 /* MenuView.swift */,
+				A10000001ABC000000000041 /* EditAccountView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -177,6 +180,7 @@
 				A10000001ABC000000000011 /* SettingsView.swift in Sources */,
 				A10000001ABC000000000013 /* MenuView.swift in Sources */,
 				A10000001ABC000000000036 /* NotificationService.swift in Sources */,
+				A10000001ABC000000000040 /* EditAccountView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/OnCallNotify/Models/Models.swift
+++ b/OnCallNotify/Models/Models.swift
@@ -162,6 +162,7 @@ struct UserDetail: Codable {
 // MARK: - Multi-Account Models
 
 enum ServiceType: String, Codable, CaseIterable {
+    case demo = "Demo Mode"
     case pagerDuty = "PagerDuty"
     // Future services:
     // case atlassianCompass = "Atlassian Compass"
@@ -172,6 +173,55 @@ enum ServiceType: String, Codable, CaseIterable {
 
     var displayName: String {
         rawValue
+    }
+
+    var requiresAPIToken: Bool {
+        self != .demo
+    }
+}
+
+enum DemoScenario: String, Codable, CaseIterable, Identifiable {
+    case reviewOverview
+    case activeIncident
+    case shiftHandoff
+    case quietShift
+
+    var id: String {
+        rawValue
+    }
+
+    var displayName: String {
+        switch self {
+        case .reviewOverview:
+            "Review Overview"
+        case .activeIncident:
+            "Active Incident"
+        case .shiftHandoff:
+            "Shift Handoff"
+        case .quietShift:
+            "Quiet Shift"
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .reviewOverview:
+            "Shows the main reviewer path with mixed incidents and active on-call status."
+        case .activeIncident:
+            "Highlights multiple triggered incidents and in-app acknowledge actions."
+        case .shiftHandoff:
+            "Shows acknowledged incidents, upcoming coverage, and reduced alert noise."
+        case .quietShift:
+            "Shows the calm-state experience with no current incidents."
+        }
+    }
+}
+
+struct DemoConfiguration: Codable {
+    var selectedScenario: DemoScenario
+
+    init(selectedScenario: DemoScenario = .reviewOverview) {
+        self.selectedScenario = selectedScenario
     }
 }
 
@@ -190,6 +240,14 @@ struct Account: Codable, Identifiable, Equatable {
 
     static func == (lhs: Account, rhs: Account) -> Bool {
         lhs.id == rhs.id
+    }
+
+    var requiresAPIToken: Bool {
+        serviceType.requiresAPIToken
+    }
+
+    var isDemoAccount: Bool {
+        serviceType == .demo
     }
 }
 
@@ -222,6 +280,7 @@ struct AccountAlertSummary {
     var acknowledgedCount: Int
     var unacknowledgedCount: Int
     var isOnCall: Bool
+    var nextOnCallShift: Date?
     var incidents: [Incident]
 }
 
@@ -258,7 +317,7 @@ enum OnCallError: Error, LocalizedError {
         case .invalidURL:
             "Configuration error. Please check your settings."
         case .noAPIToken:
-            "No API token found. Please configure in Settings."
+            "No account credentials found. Add a PagerDuty account or enable Demo Mode in Settings."
         case .invalidResponse:
             "Unable to process server response. Please try again."
         case .unauthorized:
@@ -272,7 +331,7 @@ enum OnCallError: Error, LocalizedError {
                 "Unable to complete request. Please try again."
             }
         case let .apiError(_, userMessage):
-            userMessage ?? "Unable to connect to PagerDuty. Please check your token and connection."
+            userMessage ?? "Unable to connect to the selected service. Please check your settings."
         case let .networkError(_, userMessage):
             userMessage ?? "Network connection error. Please check your internet connection."
         case let .acknowledgmentFailed(message):

--- a/OnCallNotify/Services/KeychainHelper.swift
+++ b/OnCallNotify/Services/KeychainHelper.swift
@@ -13,6 +13,8 @@ class KeychainHelper {
 
     private let service = "com.oncall.notify"
     private let accountsKey = "accounts-list" // Stores list of account IDs
+    private let defaultDemoSeedKey = "com.oncall.notify.has-seeded-default-demo-account"
+    private let defaultDemoAccountId = "app-store-demo"
     // Construct API token key pieces dynamically to avoid detect-secrets false positives.
     // We expose a prefix used for per-account keys (with trailing dash) and a
     // legacy key identifier (without trailing dash) for migration lookups.
@@ -32,9 +34,10 @@ class KeychainHelper {
         guard let data = getKeychainData(account: accountsKey),
               let accounts = try? JSONDecoder().decode([Account].self, from: data) else {
             // Try to migrate legacy single-account setup
-            return migrateLegacyAccount()
+            let migratedAccounts = migrateLegacyAccount()
+            return seedDefaultDemoAccountIfNeeded(existingAccounts: migratedAccounts)
         }
-        return accounts
+        return seedDefaultDemoAccountIfNeeded(existingAccounts: accounts)
     }
 
     /// Save accounts list
@@ -55,8 +58,10 @@ class KeychainHelper {
         }
 
         // Save API token for this account
-        guard saveAPIToken(apiToken, forAccountId: account.id) else {
-            return false
+        if account.requiresAPIToken {
+            guard saveAPIToken(apiToken, forAccountId: account.id) else {
+                return false
+            }
         }
 
         // Add account to list
@@ -79,12 +84,15 @@ class KeychainHelper {
     /// Delete an account
     func deleteAccount(accountId: String) -> Bool {
         var accounts = getAccounts()
+        let accountToDelete = accounts.first { $0.id == accountId }
 
         // Remove from list
         accounts.removeAll { $0.id == accountId }
 
         // Delete API token
-        _ = deleteAPIToken(forAccountId: accountId)
+        if let accountToDelete, accountToDelete.requiresAPIToken {
+            _ = deleteAPIToken(forAccountId: accountId)
+        }
 
         return saveAccounts(accounts)
     }
@@ -208,6 +216,31 @@ class KeychainHelper {
         _ = deleteAPIToken()
 
         return [defaultAccount]
+    }
+
+    private func seedDefaultDemoAccountIfNeeded(existingAccounts: [Account]) -> [Account] {
+        guard existingAccounts.isEmpty else {
+            return existingAccounts
+        }
+
+        let defaults = UserDefaults.standard
+        guard !defaults.bool(forKey: defaultDemoSeedKey) else {
+            return existingAccounts
+        }
+
+        let demoAccount = Account(
+            id: defaultDemoAccountId,
+            name: "App Store Demo",
+            serviceType: .demo,
+            isEnabled: true
+        )
+
+        guard saveAccounts([demoAccount]) else {
+            return existingAccounts
+        }
+
+        defaults.set(true, forKey: defaultDemoSeedKey)
+        return [demoAccount]
     }
 
     // MARK: - Private Helpers

--- a/OnCallNotify/Services/NotificationService.swift
+++ b/OnCallNotify/Services/NotificationService.swift
@@ -54,7 +54,7 @@ class NotificationService: NSObject {
         guard notificationPermissionGranted else { return }
 
         let content = UNMutableNotificationContent()
-        content.title = "New PagerDuty Incident"
+        content.title = "New Incident"
         content.body = incident.title
         content.sound = .default
 

--- a/OnCallNotify/Services/OnCallService.swift
+++ b/OnCallNotify/Services/OnCallService.swift
@@ -5,8 +5,76 @@
 //  Created by OnCall Notify
 //
 
+// swiftlint:disable file_length
 import Foundation
 import os.log
+
+protocol AccountServicing: AnyObject {
+    var account: Account { get }
+
+    func updateAccount(_ newAccount: Account)
+    func fetchData() async throws -> AccountAlertSummary
+    func acknowledgeIncident(incidentId: String) async throws
+    func performAcknowledgment(incidentId: String) async throws
+    func testConnection() async -> Bool
+}
+
+protocol ChangeTrackingAccountService: AnyObject {
+    var previousIncidentStatuses: [String: IncidentStatus] { get set }
+    var previousOnCallStatus: Bool { get set }
+    var isFirstFetch: Bool { get set }
+}
+
+extension ChangeTrackingAccountService {
+    func detectAndNotifyChanges(incidents: [Incident], isOnCall: Bool) {
+        let currentIncidentStatuses = Dictionary(uniqueKeysWithValues: incidents.map { ($0.id, $0.status) })
+        let currentIncidentIds = Set(currentIncidentStatuses.keys)
+        let previousIncidentIds = Set(previousIncidentStatuses.keys)
+
+        for incident in incidents {
+            if let previousStatus = previousIncidentStatuses[incident.id] {
+                if previousStatus != incident.status {
+                    if previousStatus == .triggered, incident.status == .acknowledged {
+                        NotificationService.shared.removeIncidentNotification(incidentId: incident.id)
+                        NotificationService.shared.sendIncidentAcknowledgedNotification(incident: incident)
+                    } else if incident.status == .resolved {
+                        NotificationService.shared.sendIncidentResolvedNotification(incident: incident)
+                        NotificationService.shared.removeIncidentNotification(incidentId: incident.id)
+                    }
+                }
+            } else {
+                if incident.status == .triggered {
+                    NotificationService.shared.sendIncidentNotification(incident: incident)
+                } else if incident.status == .acknowledged {
+                    NotificationService.shared.sendIncidentAcknowledgedNotification(incident: incident)
+                }
+            }
+        }
+
+        let resolvedIncidentIds = previousIncidentIds.subtracting(currentIncidentIds)
+        for incidentId in resolvedIncidentIds {
+            NotificationService.shared.removeIncidentNotification(incidentId: incidentId)
+        }
+
+        if isOnCall != previousOnCallStatus {
+            if isOnCall {
+                NotificationService.shared.sendOnCallStartNotification(nextShift: nil)
+            } else {
+                NotificationService.shared.sendOnCallEndNotification(nextShift: nil)
+            }
+        }
+    }
+
+    func updateChangeTracking(incidents: [Incident], isOnCall: Bool) {
+        if !isFirstFetch {
+            detectAndNotifyChanges(incidents: incidents, isOnCall: isOnCall)
+        }
+
+        previousIncidentStatuses = Dictionary(uniqueKeysWithValues: incidents.map { ($0.id, $0.status) })
+        previousOnCallStatus = isOnCall
+        isFirstFetch = false
+    }
+}
 
 @MainActor
 class OnCallService: ObservableObject {
@@ -16,10 +84,9 @@ class OnCallService: ObservableObject {
     @Published var isLoading = false
     @Published var lastError: Error?
 
-    private var accountServices: [String: AccountService] = [:] // accountId -> service
+    private var accountServices: [String: AccountServicing] = [:]
     private var updateTimer: Timer?
 
-    // Rate limiting and retry logic
     private var lastFetchTime: Date?
     private let minimumFetchInterval: TimeInterval = 5.0
 
@@ -36,37 +103,89 @@ class OnCallService: ObservableObject {
 
     func initializeAccountServices() {
         let accounts = KeychainHelper.shared.getAccounts()
+        let enabledAccounts = accounts.filter(\.isEnabled)
+        let enabledAccountIds = Set(enabledAccounts.map(\.id))
 
-        // Build set of enabled account IDs
-        let enabledAccountIds = Set(accounts.filter { $0.isEnabled }.map { $0.id })
-
-        // Remove services for accounts that no longer exist OR are disabled
         accountServices = accountServices.filter { enabledAccountIds.contains($0.key) }
 
-        // Create or update services for each enabled account
-        for account in accounts where account.isEnabled {
-            if accountServices[account.id] == nil {
-                accountServices[account.id] = AccountService(account: account)
-            } else {
-                accountServices[account.id]?.updateAccount(account)
+        for account in enabledAccounts {
+            if let existingService = accountServices[account.id] {
+                existingService.updateAccount(account)
+                continue
+            }
+
+            switch account.serviceType {
+            case .pagerDuty:
+                accountServices[account.id] = PagerDutyAccountService(account: account)
+            case .demo:
+                accountServices[account.id] = DemoAccountService(account: account)
             }
         }
     }
 
     func reloadAccounts() {
         initializeAccountServices()
-        refreshData()
+        refreshData(force: true)
+    }
+
+    func enabledAccounts() -> [Account] {
+        KeychainHelper.shared.getAccounts().filter(\.isEnabled)
+    }
+
+    func hasEnabledDemoAccount() -> Bool {
+        enabledAccounts().contains { $0.isDemoAccount }
+    }
+
+    func primaryDemoAccount() -> Account? {
+        enabledAccounts().first { $0.isDemoAccount }
+    }
+
+    func primaryLiveAccount() -> Account? {
+        enabledAccounts().first { !$0.isDemoAccount }
+    }
+
+    func demoConfiguration(for accountId: String) -> DemoConfiguration? {
+        guard let service = accountServices[accountId] as? DemoAccountService else {
+            return nil
+        }
+
+        return service.configuration()
+    }
+
+    func setDemoScenario(_ scenario: DemoScenario, for accountId: String) {
+        guard let service = accountServices[accountId] as? DemoAccountService else {
+            return
+        }
+
+        service.setScenario(scenario)
+        refreshData(force: true)
+    }
+
+    func advanceDemoScenario(for accountId: String) {
+        guard let service = accountServices[accountId] as? DemoAccountService else {
+            return
+        }
+
+        service.advanceScenario()
+        refreshData(force: true)
+    }
+
+    func resetDemoScenario(for accountId: String) {
+        guard let service = accountServices[accountId] as? DemoAccountService else {
+            return
+        }
+
+        service.resetScenario()
+        refreshData(force: true)
     }
 
     // MARK: - Auto Update
 
     func startAutoUpdate() {
-        // Update immediately
         Task {
             await fetchAllData()
         }
 
-        // Then update every 60 seconds
         updateTimer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { [weak self] _ in
             Task {
                 await self?.fetchAllData()
@@ -82,7 +201,6 @@ class OnCallService: ObservableObject {
     // MARK: - Main Fetch Method
 
     func fetchAllData() async {
-        // Check if we have any accounts
         guard !accountServices.isEmpty else {
             lastError = OnCallError.noAPIToken
             alertSummary = AlertSummary()
@@ -92,7 +210,6 @@ class OnCallService: ObservableObject {
         isLoading = true
         lastError = nil
 
-        // Fetch data from all account services
         await withTaskGroup(of: (String, AccountAlertSummary?, Error?).self) { group in
             for (accountId, service) in accountServices {
                 group.addTask {
@@ -110,9 +227,9 @@ class OnCallService: ObservableObject {
             var firstError: Error?
 
             for await (accountId, summary, error) in group {
-                if let summary = summary {
+                if let summary {
                     accountSummaries[accountId] = summary
-                } else if let error = error {
+                } else if let error {
                     hasError = true
                     if firstError == nil {
                         firstError = error
@@ -120,12 +237,10 @@ class OnCallService: ObservableObject {
                 }
             }
 
-            // Aggregate results
             aggregateResults(accountSummaries: accountSummaries)
 
-            // Set error if any account failed
-            if hasError, let error = firstError {
-                lastError = error
+            if hasError, let firstError {
+                lastError = firstError
             }
         }
 
@@ -136,8 +251,8 @@ class OnCallService: ObservableObject {
         var summary = AlertSummary()
         summary.accountSummaries = accountSummaries
 
-        // Aggregate totals across all accounts
         var allIncidents: [Incident] = []
+        var nextShiftCandidates: [Date] = []
 
         for (_, accountSummary) in accountSummaries {
             summary.totalAlerts += accountSummary.totalAlerts
@@ -145,9 +260,12 @@ class OnCallService: ObservableObject {
             summary.unacknowledgedCount += accountSummary.unacknowledgedCount
             summary.isOnCall = summary.isOnCall || accountSummary.isOnCall
             allIncidents.append(contentsOf: accountSummary.incidents)
+
+            if let nextShift = accountSummary.nextOnCallShift {
+                nextShiftCandidates.append(nextShift)
+            }
         }
 
-        // Sort incidents by creation time (most recent first)
         allIncidents.sort { incident1, incident2 in
             let formatter = ISO8601DateFormatter()
             guard let date1 = formatter.date(from: incident1.createdAt),
@@ -158,28 +276,23 @@ class OnCallService: ObservableObject {
         }
 
         summary.incidents = allIncidents
-
+        summary.nextOnCallShift = nextShiftCandidates.min()
         alertSummary = summary
     }
 
     // MARK: - API Methods
 
     func acknowledgeAllIncidents() async throws {
-        // Get all triggered incidents
         let triggeredIncidents = alertSummary.incidents.filter { $0.status == .triggered }
 
         guard !triggeredIncidents.isEmpty else {
             return
         }
 
-        // Acknowledge each incident without refreshing after each one
         var errors: [Error] = []
         for incident in triggeredIncidents {
-            guard let accountId = incident.accountId else {
-                continue
-            }
-
-            guard let service = accountServices[accountId] else {
+            guard let accountId = incident.accountId,
+                  let service = accountServices[accountId] else {
                 continue
             }
 
@@ -190,13 +303,11 @@ class OnCallService: ObservableObject {
             }
         }
 
-        // If any errors occurred, throw the first one
         if let firstError = errors.first {
             throw firstError
         }
 
-        // Refresh data once at the end to get latest from server
-        try? await Task.sleep(nanoseconds: 1_000_000_000) // Wait 1 second
+        try? await Task.sleep(nanoseconds: 1_000_000_000)
         await fetchAllData()
     }
 
@@ -210,7 +321,6 @@ class OnCallService: ObservableObject {
 
         try await service.acknowledgeIncident(incidentId: incidentId)
 
-        // Refresh data after acknowledgment
         try? await Task.sleep(nanoseconds: 1_000_000_000)
         await fetchAllData()
     }
@@ -224,9 +334,9 @@ class OnCallService: ObservableObject {
 
     // MARK: - Public Helper Methods
 
-    func refreshData() {
-        // Prevent rapid refresh spam
-        if let lastFetch = lastFetchTime,
+    func refreshData(force: Bool = false) {
+        if !force,
+           let lastFetch = lastFetchTime,
            Date().timeIntervalSince(lastFetch) < minimumFetchInterval {
             Self.logger.debug("Refresh throttled - minimum interval not met")
             return
@@ -239,23 +349,19 @@ class OnCallService: ObservableObject {
         }
     }
 
-    // MARK: - Secure Logging
-
     private static let logger = Logger(subsystem: "com.oncall.notify", category: "api")
 }
 
-// MARK: - AccountService
+// MARK: - PagerDuty Account Service
 
-/// Service that manages API calls for a single account
-class AccountService {
-    private var account: Account
+class PagerDutyAccountService: AccountServicing, ChangeTrackingAccountService {
+    private(set) var account: Account
     private let baseURL = "https://api.pagerduty.com"
     private var currentUserId: String?
 
-    // Track previous state for change detection per account
-    private var previousIncidentStatuses: [String: IncidentStatus] = [:]
-    private var previousOnCallStatus: Bool = false
-    private var isFirstFetch: Bool = true
+    var previousIncidentStatuses: [String: IncidentStatus] = [:]
+    var previousOnCallStatus: Bool = false
+    var isFirstFetch: Bool = true
 
     private static let iso8601Formatter = ISO8601DateFormatter()
     private let futureScheduleLookupDays: Int = 30
@@ -276,32 +382,24 @@ class AccountService {
     }
 
     func updateAccount(_ newAccount: Account) {
-        self.account = newAccount
+        account = newAccount
     }
-
-    // MARK: - Main Fetch
 
     func fetchData() async throws -> AccountAlertSummary {
         guard let apiToken = KeychainHelper.shared.getAPIToken(forAccountId: account.id) else {
             throw OnCallError.noAPIToken
         }
 
-        // First, get current user ID if we don't have it
         if currentUserId == nil {
             try await fetchCurrentUser(apiToken: apiToken)
         }
 
-        // Fetch incidents and on-call status in parallel
         async let incidents = fetchIncidents(apiToken: apiToken)
         async let oncalls = fetchOncalls(apiToken: apiToken)
 
         let (fetchedIncidents, fetchedOncalls) = try await (incidents, oncalls)
-
-        // Process and return summary
         return processData(incidents: fetchedIncidents, oncalls: fetchedOncalls)
     }
-
-    // MARK: - API Methods
 
     func acknowledgeIncident(incidentId: String) async throws {
         try await performAcknowledgment(incidentId: incidentId)
@@ -358,8 +456,6 @@ class AccountService {
         }
     }
 
-    // MARK: - Private API Methods
-
     private func fetchCurrentUser(apiToken: String) async throws {
         let endpoint = "/users/me"
         let url = try buildURL(endpoint: endpoint)
@@ -381,7 +477,8 @@ class AccountService {
             } else {
                 throw OnCallError.apiError(
                     technicalMessage: "HTTP \(httpResponse.statusCode)",
-                    userMessage: "Unable to complete request")
+                    userMessage: "Unable to complete request"
+                )
             }
         }
 
@@ -428,14 +525,14 @@ class AccountService {
             } else {
                 throw OnCallError.apiError(
                     technicalMessage: "HTTP \(httpResponse.statusCode)",
-                    userMessage: "Unable to complete request")
+                    userMessage: "Unable to complete request"
+                )
             }
         }
 
         let decoder = JSONDecoder()
         let incidentsResponse = try decoder.decode(PagerDutyIncidentsResponse.self, from: data)
 
-        // Tag incidents with account ID
         return incidentsResponse.incidents.map { incident in
             var taggedIncident = incident
             taggedIncident.accountId = account.id
@@ -450,11 +547,11 @@ class AccountService {
         }
 
         let now = Date()
-        guard let futureDate = Calendar.current.date(
-                byAdding: .day, value: futureScheduleLookupDays, to: now) else {
+        guard let futureDate = Calendar.current.date(byAdding: .day, value: futureScheduleLookupDays, to: now) else {
             throw OnCallError.apiError(
                 technicalMessage: "Failed to calculate future date",
-                userMessage: "Unable to process schedule data")
+                userMessage: "Unable to process schedule data"
+            )
         }
 
         let sinceParam = Self.iso8601Formatter.string(from: now)
@@ -493,17 +590,15 @@ class AccountService {
             } else {
                 throw OnCallError.apiError(
                     technicalMessage: "HTTP \(httpResponse.statusCode)",
-                    userMessage: "Unable to complete request")
+                    userMessage: "Unable to complete request"
+                )
             }
         }
 
         let decoder = JSONDecoder()
         let oncallsResponse = try decoder.decode(PagerDutyOncallsResponse.self, from: data)
-
         return oncallsResponse.oncalls
     }
-
-    // MARK: - Helper Methods
 
     private func buildURL(endpoint: String) throws -> URL {
         guard let url = URL(string: baseURL + endpoint) else {
@@ -523,33 +618,35 @@ class AccountService {
     }
 
     private func processData(incidents: [Incident], oncalls: [Oncall]) -> AccountAlertSummary {
-        // Process on-call status
         let now = Date()
         var isCurrentlyOnCall = false
+        var nextOnCallShift: Date?
 
         for oncall in oncalls {
             if let startString = oncall.start,
+               let startDate = Self.iso8601Formatter.date(from: startString),
+               startDate > now {
+                if let currentNextShift = nextOnCallShift {
+                    if startDate < currentNextShift {
+                        nextOnCallShift = startDate
+                    }
+                } else {
+                    nextOnCallShift = startDate
+                }
+            }
+
+            if let startString = oncall.start,
                let endString = oncall.end,
                let startDate = Self.iso8601Formatter.date(from: startString),
-               let endDate = Self.iso8601Formatter.date(from: endString) {
-                if startDate <= now, endDate > now {
-                    isCurrentlyOnCall = true
-                    break
-                }
+               let endDate = Self.iso8601Formatter.date(from: endString),
+               startDate <= now,
+               endDate > now {
+                isCurrentlyOnCall = true
             }
         }
 
-        // Detect changes and send notifications (skip on first fetch)
-        if !isFirstFetch {
-            detectAndNotifyChanges(incidents: incidents, isOnCall: isCurrentlyOnCall)
-        }
+        updateChangeTracking(incidents: incidents, isOnCall: isCurrentlyOnCall)
 
-        // Update previous state
-        previousIncidentStatuses = Dictionary(uniqueKeysWithValues: incidents.map { ($0.id, $0.status) })
-        previousOnCallStatus = isCurrentlyOnCall
-        isFirstFetch = false
-
-        // Return summary
         return AccountAlertSummary(
             accountId: account.id,
             accountName: account.name,
@@ -557,50 +654,373 @@ class AccountService {
             acknowledgedCount: incidents.filter { $0.status == .acknowledged }.count,
             unacknowledgedCount: incidents.filter { $0.status == .triggered }.count,
             isOnCall: isCurrentlyOnCall,
+            nextOnCallShift: nextOnCallShift,
             incidents: incidents
         )
     }
+}
 
-    private func detectAndNotifyChanges(incidents: [Incident], isOnCall: Bool) {
-        let currentIncidentStatuses = Dictionary(uniqueKeysWithValues: incidents.map { ($0.id, $0.status) })
-        let currentIncidentIds = Set(currentIncidentStatuses.keys)
-        let previousIncidentIds = Set(previousIncidentStatuses.keys)
+// MARK: - Demo Account Service
 
-        // Detect new incidents and status transitions
-        for incident in incidents {
-            if let previousStatus = previousIncidentStatuses[incident.id] {
-                if previousStatus != incident.status {
-                    if previousStatus == .triggered, incident.status == .acknowledged {
-                        NotificationService.shared.removeIncidentNotification(incidentId: incident.id)
-                        NotificationService.shared.sendIncidentAcknowledgedNotification(incident: incident)
-                    } else if incident.status == .resolved {
-                        NotificationService.shared.sendIncidentResolvedNotification(incident: incident)
-                        NotificationService.shared.removeIncidentNotification(incidentId: incident.id)
-                    }
-                }
-            } else {
-                // New incident
-                if incident.status == .triggered {
-                    NotificationService.shared.sendIncidentNotification(incident: incident)
-                } else if incident.status == .acknowledged {
-                    NotificationService.shared.sendIncidentAcknowledgedNotification(incident: incident)
-                }
-            }
+class DemoAccountService: AccountServicing, ChangeTrackingAccountService {
+    private(set) var account: Account
+
+    var previousIncidentStatuses: [String: IncidentStatus] = [:]
+    var previousOnCallStatus: Bool = false
+    var isFirstFetch: Bool = true
+
+    private let stateStore = DemoStateStore.shared
+
+    init(account: Account) {
+        self.account = account
+    }
+
+    func updateAccount(_ newAccount: Account) {
+        account = newAccount
+    }
+
+    func fetchData() async throws -> AccountAlertSummary {
+        let state = stateStore.state(for: account)
+        updateChangeTracking(incidents: state.incidents, isOnCall: state.isOnCall)
+
+        return AccountAlertSummary(
+            accountId: account.id,
+            accountName: account.name,
+            totalAlerts: state.incidents.count,
+            acknowledgedCount: state.incidents.filter { $0.status == .acknowledged }.count,
+            unacknowledgedCount: state.incidents.filter { $0.status == .triggered }.count,
+            isOnCall: state.isOnCall,
+            nextOnCallShift: state.nextOnCallShift,
+            incidents: state.incidents
+        )
+    }
+
+    func acknowledgeIncident(incidentId: String) async throws {
+        try await performAcknowledgment(incidentId: incidentId)
+    }
+
+    func performAcknowledgment(incidentId: String) async throws {
+        guard stateStore.acknowledgeIncident(withId: incidentId, for: account) else {
+            throw OnCallError.acknowledgmentFailed(message: "Unable to acknowledge the demo incident")
+        }
+    }
+
+    func testConnection() async -> Bool {
+        true
+    }
+
+    func configuration() -> DemoConfiguration {
+        stateStore.configuration(for: account.id)
+    }
+
+    func setScenario(_ scenario: DemoScenario) {
+        stateStore.setScenario(scenario, for: account)
+    }
+
+    func advanceScenario() {
+        stateStore.advanceScenario(for: account)
+    }
+
+    func resetScenario() {
+        stateStore.resetScenario(for: account)
+    }
+}
+
+private struct DemoState: Codable {
+    var scenario: DemoScenario
+    var isOnCall: Bool
+    var nextOnCallShift: Date?
+    var incidents: [Incident]
+}
+
+private class DemoStateStore {
+    static let shared = DemoStateStore()
+
+    private let defaults = UserDefaults.standard
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+    private let stateKeyPrefix = "com.oncall.notify.demo.state."
+    private let configurationKeyPrefix = "com.oncall.notify.demo.configuration."
+    private let iso8601Formatter = ISO8601DateFormatter()
+
+    private init() {}
+
+    func configuration(for accountId: String) -> DemoConfiguration {
+        guard let data = defaults.data(forKey: configurationKeyPrefix + accountId),
+              let configuration = try? decoder.decode(DemoConfiguration.self, from: data) else {
+            return DemoConfiguration()
         }
 
-        // Detect resolved incidents
-        let resolvedIncidentIds = previousIncidentIds.subtracting(currentIncidentIds)
-        for incidentId in resolvedIncidentIds {
-            NotificationService.shared.removeIncidentNotification(incidentId: incidentId)
+        return configuration
+    }
+
+    func state(for account: Account) -> DemoState {
+        if let data = defaults.data(forKey: stateKeyPrefix + account.id),
+           let state = try? decoder.decode(DemoState.self, from: data) {
+            return normalizeState(state, accountId: account.id)
         }
 
-        // Detect on-call status changes
-        if isOnCall != previousOnCallStatus {
-            if isOnCall {
-                NotificationService.shared.sendOnCallStartNotification(nextShift: nil)
-            } else {
-                NotificationService.shared.sendOnCallEndNotification(nextShift: nil)
-            }
+        let configuration = configuration(for: account.id)
+        let state = makeState(for: configuration.selectedScenario, accountId: account.id)
+        save(state: state, for: account.id)
+        return state
+    }
+
+    func setScenario(_ scenario: DemoScenario, for account: Account) {
+        save(configuration: DemoConfiguration(selectedScenario: scenario), for: account.id)
+        save(state: makeState(for: scenario, accountId: account.id), for: account.id)
+    }
+
+    func advanceScenario(for account: Account) {
+        let currentConfiguration = configuration(for: account.id)
+        let scenarios = DemoScenario.allCases
+        guard let currentIndex = scenarios.firstIndex(of: currentConfiguration.selectedScenario) else {
+            setScenario(.reviewOverview, for: account)
+            return
         }
+
+        let nextIndex = scenarios.index(after: currentIndex)
+        let nextScenario = nextIndex < scenarios.endIndex ? scenarios[nextIndex] : scenarios[scenarios.startIndex]
+        setScenario(nextScenario, for: account)
+    }
+
+    func resetScenario(for account: Account) {
+        let currentConfiguration = configuration(for: account.id)
+        save(state: makeState(for: currentConfiguration.selectedScenario, accountId: account.id), for: account.id)
+    }
+
+    func acknowledgeIncident(withId incidentId: String, for account: Account) -> Bool {
+        var state = state(for: account)
+        guard let index = state.incidents.firstIndex(where: { $0.id == incidentId }) else {
+            return false
+        }
+
+        let incident = state.incidents[index]
+        guard incident.status == .triggered else {
+            return true
+        }
+
+        let updatedDate = iso8601Formatter.string(from: Date())
+        state.incidents[index] = incident.updating(
+            status: .acknowledged,
+            updatedAt: updatedDate,
+            lastStatusChangeAt: updatedDate
+        )
+        save(state: state, for: account.id)
+        return true
+    }
+
+    private func save(configuration: DemoConfiguration, for accountId: String) {
+        guard let data = try? encoder.encode(configuration) else {
+            return
+        }
+
+        defaults.set(data, forKey: configurationKeyPrefix + accountId)
+    }
+
+    private func save(state: DemoState, for accountId: String) {
+        guard let data = try? encoder.encode(state) else {
+            return
+        }
+
+        defaults.set(data, forKey: stateKeyPrefix + accountId)
+    }
+
+    private func normalizeState(_ state: DemoState, accountId: String) -> DemoState {
+        var normalizedState = state
+        normalizedState.incidents = normalizedState.incidents.map { incident in
+            var taggedIncident = incident
+            taggedIncident.accountId = accountId
+            return taggedIncident
+        }
+        return normalizedState
+    }
+
+    private func makeState(for scenario: DemoScenario, accountId: String) -> DemoState {
+        let now = Date()
+        switch scenario {
+        case .reviewOverview:
+            return makeReviewOverviewState(now: now, accountId: accountId)
+        case .activeIncident:
+            return makeActiveIncidentState(now: now, accountId: accountId)
+        case .shiftHandoff:
+            return makeShiftHandoffState(now: now, accountId: accountId)
+        case .quietShift:
+            return makeQuietShiftState(now: now, accountId: accountId)
+        }
+    }
+
+    private func makeReviewOverviewState(now: Date, accountId: String) -> DemoState {
+        DemoState(
+            scenario: .reviewOverview,
+            isOnCall: true,
+            nextOnCallShift: Calendar.current.date(byAdding: .day, value: 5, to: now),
+            incidents: [
+                makeIncident(
+                    id: "demo-review-triggered",
+                    title: "Payments API latency crossing SLO",
+                    summary: "Latency to the payments API is above the paging threshold.",
+                    status: .triggered,
+                    urgency: "high",
+                    createdAt: now.addingTimeInterval(-12 * 60),
+                    updatedAt: now.addingTimeInterval(-12 * 60),
+                    serviceName: "Payments API",
+                    incidentNumber: 4201,
+                    accountId: accountId
+                ),
+                makeIncident(
+                    id: "demo-review-acknowledged",
+                    title: "Background jobs retry queue growing",
+                    summary: "Retry backlog is elevated but being actively worked.",
+                    status: .acknowledged,
+                    urgency: "high",
+                    createdAt: now.addingTimeInterval(-52 * 60),
+                    updatedAt: now.addingTimeInterval(-18 * 60),
+                    serviceName: "Worker Fleet",
+                    incidentNumber: 4200,
+                    accountId: accountId
+                )
+            ]
+        )
+    }
+
+    private func makeActiveIncidentState(now: Date, accountId: String) -> DemoState {
+        DemoState(
+            scenario: .activeIncident,
+            isOnCall: true,
+            nextOnCallShift: Calendar.current.date(byAdding: .day, value: 3, to: now),
+            incidents: [
+                makeIncident(
+                    id: "demo-active-1",
+                    title: "Login service elevated 5xx rate",
+                    summary: "Customer sign-ins are failing for multiple regions.",
+                    status: .triggered,
+                    urgency: "high",
+                    createdAt: now.addingTimeInterval(-6 * 60),
+                    updatedAt: now.addingTimeInterval(-6 * 60),
+                    serviceName: "Identity Platform",
+                    incidentNumber: 4301,
+                    accountId: accountId
+                ),
+                makeIncident(
+                    id: "demo-active-2",
+                    title: "Search index replication lag",
+                    summary: "Search results are stale while replicas catch up.",
+                    status: .triggered,
+                    urgency: "high",
+                    createdAt: now.addingTimeInterval(-24 * 60),
+                    updatedAt: now.addingTimeInterval(-24 * 60),
+                    serviceName: "Search Cluster",
+                    incidentNumber: 4300,
+                    accountId: accountId
+                ),
+                makeIncident(
+                    id: "demo-active-3",
+                    title: "Billing exports delayed",
+                    summary: "Scheduled exports are delayed but customer traffic is unaffected.",
+                    status: .acknowledged,
+                    urgency: "low",
+                    createdAt: now.addingTimeInterval(-90 * 60),
+                    updatedAt: now.addingTimeInterval(-40 * 60),
+                    serviceName: "Billing Pipeline",
+                    incidentNumber: 4298,
+                    accountId: accountId
+                )
+            ]
+        )
+    }
+
+    private func makeShiftHandoffState(now: Date, accountId: String) -> DemoState {
+        DemoState(
+            scenario: .shiftHandoff,
+            isOnCall: false,
+            nextOnCallShift: Calendar.current.date(byAdding: .hour, value: 6, to: now),
+            incidents: [
+                makeIncident(
+                    id: "demo-handoff-1",
+                    title: "Synthetic checkout monitor flapping",
+                    summary: "Intermittent monitor failures were acknowledged during handoff.",
+                    status: .acknowledged,
+                    urgency: "low",
+                    createdAt: now.addingTimeInterval(-3 * 3600),
+                    updatedAt: now.addingTimeInterval(-45 * 60),
+                    serviceName: "Checkout Experience",
+                    incidentNumber: 4288,
+                    accountId: accountId
+                )
+            ]
+        )
+    }
+
+    private func makeQuietShiftState(now: Date, accountId: String) -> DemoState {
+        DemoState(
+            scenario: .quietShift,
+            isOnCall: false,
+            nextOnCallShift: Calendar.current.date(byAdding: .hour, value: 2, to: now),
+            incidents: []
+        )
+    }
+
+    // swiftlint:disable:next function_parameter_count
+    private func makeIncident(
+        id: String,
+        title: String,
+        summary: String,
+        status: IncidentStatus,
+        urgency: String,
+        createdAt: Date,
+        updatedAt: Date,
+        serviceName: String,
+        incidentNumber: Int,
+        accountId: String
+    ) -> Incident {
+        Incident(
+            id: id,
+            type: "incident",
+            summary: summary,
+            status: status,
+            urgency: urgency,
+            title: title,
+            createdAt: iso8601Formatter.string(from: createdAt),
+            updatedAt: iso8601Formatter.string(from: updatedAt),
+            htmlUrl: nil,
+            incidentNumber: incidentNumber,
+            service: Service(
+                id: "service-\(id)",
+                type: "service_reference",
+                summary: serviceName,
+                htmlUrl: nil
+            ),
+            assignments: nil,
+            acknowledgements: nil,
+            lastStatusChangeAt: iso8601Formatter.string(from: updatedAt),
+            accountId: accountId
+        )
+    }
+}
+
+private extension Incident {
+    func updating(
+        status: IncidentStatus,
+        updatedAt: String?,
+        lastStatusChangeAt: String?
+    ) -> Incident {
+        Incident(
+            id: id,
+            type: type,
+            summary: summary,
+            status: status,
+            urgency: urgency,
+            title: title,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+            htmlUrl: htmlUrl,
+            incidentNumber: incidentNumber,
+            service: service,
+            assignments: assignments,
+            acknowledgements: acknowledgements,
+            lastStatusChangeAt: lastStatusChangeAt,
+            accountId: accountId
+        )
     }
 }

--- a/OnCallNotify/StatusBarController.swift
+++ b/OnCallNotify/StatusBarController.swift
@@ -140,9 +140,15 @@ class StatusBarController: ObservableObject {
         }
 
         button.attributedTitle = attributedTitle
+        button.toolTip = makeTooltip(for: summary)
+    }
 
-        // Set tooltip
+    private func makeTooltip(for summary: AlertSummary) -> String {
         var tooltipParts: [String] = []
+
+        if OnCallService.shared.hasEnabledDemoAccount() {
+            tooltipParts.append("Demo Mode Enabled")
+        }
 
         if summary.isOnCall {
             tooltipParts.append("Currently On-Call")
@@ -162,7 +168,7 @@ class StatusBarController: ObservableObject {
             tooltipParts.append("No active alerts")
         }
 
-        button.toolTip = tooltipParts.joined(separator: "\n")
+        return tooltipParts.joined(separator: "\n")
     }
 
     // MARK: - Popover Actions

--- a/OnCallNotify/Views/EditAccountView.swift
+++ b/OnCallNotify/Views/EditAccountView.swift
@@ -1,0 +1,133 @@
+//
+//  EditAccountView.swift
+//  OnCallNotify
+//
+//  Created by OnCall Notify
+//
+
+import SwiftUI
+
+struct EditAccountView: View {
+    let account: Account
+    let onSave: (Account, String?) -> Void
+    let onCancel: () -> Void
+
+    @State private var accountName: String = ""
+    @State private var apiToken = ""
+    @State private var showError = false
+    @State private var errorMessage = ""
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("Edit Account")
+                    .font(.title2)
+                    .fontWeight(.semibold)
+                Spacer()
+            }
+            .padding()
+
+            Divider()
+
+            Form {
+                Section {
+                    TextField("Account Name", text: $accountName)
+                        .textFieldStyle(.roundedBorder)
+
+                    HStack {
+                        Text("Service Type:")
+                        Spacer()
+                        Text(account.serviceType.displayName)
+                            .foregroundColor(.secondary)
+                    }
+
+                    if account.requiresAPIToken {
+                        SecureField("New API Token (leave blank to keep current)", text: $apiToken)
+                            .textFieldStyle(.roundedBorder)
+                    }
+                } header: {
+                    Text("Account Details")
+                }
+            }
+            .formStyle(.grouped)
+            .padding()
+
+            if showError {
+                HStack {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundColor(.orange)
+                    Text(errorMessage)
+                        .font(.caption)
+                    Spacer()
+                }
+                .padding()
+                .background(Color.orange.opacity(0.1))
+            }
+
+            Divider()
+
+            HStack {
+                Button("Cancel", action: onCancel)
+                    .keyboardShortcut(.cancelAction)
+
+                Spacer()
+
+                Button("Save") {
+                    saveAccount()
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(accountName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+            .padding()
+        }
+        .frame(width: 520, height: 350)
+        .onAppear {
+            accountName = account.name
+        }
+    }
+
+    private func saveAccount() {
+        let trimmedName = accountName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedToken = apiToken.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !trimmedName.isEmpty else {
+            showError = true
+            errorMessage = "Please enter an account name"
+            return
+        }
+
+        if account.requiresAPIToken, !trimmedToken.isEmpty {
+            let validation = validateAPIToken(trimmedToken)
+            guard validation.isValid else {
+                showError = true
+                errorMessage = validation.message ?? "Invalid API token"
+                return
+            }
+        }
+
+        var updatedAccount = account
+        updatedAccount.name = trimmedName
+
+        let tokenToSave: String? = trimmedToken.isEmpty ? nil : trimmedToken
+        onSave(updatedAccount, tokenToSave)
+    }
+
+    private func validateAPIToken(_ token: String) -> (isValid: Bool, message: String?) {
+        let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard trimmed.count >= 20 else {
+            return (false, "API token must be at least 20 characters")
+        }
+
+        guard trimmed.count <= 100 else {
+            return (false, "API token appears to be invalid (too long)")
+        }
+
+        let allowedCharacters = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_+"))
+        guard trimmed.rangeOfCharacter(from: allowedCharacters.inverted) == nil else {
+            return (false, "API token contains invalid characters")
+        }
+
+        return (true, nil)
+    }
+}

--- a/OnCallNotify/Views/MenuView.swift
+++ b/OnCallNotify/Views/MenuView.swift
@@ -10,28 +10,35 @@ import SwiftUI
 struct MenuView: View {
     @ObservedObject var service = OnCallService.shared
 
+    private var demoAccount: Account? {
+        service.primaryDemoAccount()
+    }
+
+    private var liveAccount: Account? {
+        service.primaryLiveAccount()
+    }
+
     var body: some View {
         VStack(spacing: 0) {
-            // Header
             headerView
 
             Divider()
 
-            // Main content
             ScrollView {
                 VStack(alignment: .leading, spacing: 16) {
-                    // On-call status section
+                    if let demoAccount {
+                        demoModeSection(account: demoAccount)
+                        Divider()
+                    }
+
                     onCallStatusSection
 
                     Divider()
 
-                    // Alert summary section
                     alertSummarySection
 
                     if !service.alertSummary.incidents.isEmpty {
                         Divider()
-
-                        // Incidents list
                         incidentsSection
                     }
                 }
@@ -40,17 +47,16 @@ struct MenuView: View {
 
             Divider()
 
-            // Footer with actions
             footerView
         }
-        .frame(width: 400, height: 500)
+        .frame(width: 420, height: 540)
     }
 
     // MARK: - Header
 
     private var headerView: some View {
         HStack {
-            Image(systemName: "bell.fill")
+            Image(systemName: service.alertSummary.isOnCall ? "bell.fill" : "bell")
                 .font(.title2)
                 .foregroundColor(service.alertSummary.isOnCall ? .blue : .secondary)
 
@@ -71,7 +77,12 @@ struct MenuView: View {
                     Text(error.localizedDescription)
                         .font(.caption)
                         .foregroundColor(.red)
-                        .lineLimit(1)
+                        .lineLimit(2)
+                } else if let demoAccount,
+                          let configuration = service.demoConfiguration(for: demoAccount.id) {
+                    Text("Demo Mode • \(configuration.selectedScenario.displayName)")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
                 } else {
                     Text("Updated just now")
                         .font(.caption)
@@ -81,17 +92,76 @@ struct MenuView: View {
 
             Spacer()
 
-            Button(
-                action: {
-                    service.refreshData()
-                },
-                label: {
-                    Image(systemName: "arrow.clockwise")
-                })
-                .buttonStyle(.plain)
-                .help("Refresh")
+            Button {
+                service.refreshData(force: true)
+            } label: {
+                Image(systemName: "arrow.clockwise")
+            }
+            .buttonStyle(.plain)
+            .help("Refresh")
         }
         .padding()
+    }
+
+    // MARK: - Demo Mode
+
+    private func demoModeSection(account: Account) -> some View {
+        let configuration = service.demoConfiguration(for: account.id) ?? DemoConfiguration()
+
+        return VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Label("Demo Mode", systemImage: "play.square.fill")
+                    .font(.headline)
+                    .foregroundColor(.blue)
+
+                Spacer()
+
+                Text(account.name)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
+            Text(
+                "This demo runs without PagerDuty credentials and exercises the same " +
+                    "menu, refresh, on-call, and acknowledge flows used by live accounts."
+            )
+            .font(.caption)
+            .foregroundColor(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+
+            Picker("Scenario", selection: demoScenarioBinding(for: account.id)) {
+                ForEach(DemoScenario.allCases) { scenario in
+                    Text(scenario.displayName).tag(scenario)
+                }
+            }
+            .pickerStyle(.menu)
+
+            Text(configuration.selectedScenario.description)
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            HStack {
+                Button {
+                    service.resetDemoScenario(for: account.id)
+                } label: {
+                    Label("Reset", systemImage: "arrow.counterclockwise")
+                }
+                .buttonStyle(.bordered)
+
+                Button {
+                    service.advanceDemoScenario(for: account.id)
+                } label: {
+                    Label("Next Scenario", systemImage: "arrow.right.circle")
+                }
+                .buttonStyle(.borderedProminent)
+            }
+        }
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(Color.blue.opacity(0.07))
+        )
     }
 
     // MARK: - On-Call Status
@@ -141,14 +211,12 @@ struct MenuView: View {
 
                 Spacer()
 
-                // Acknowledge All button (only show when there are unacknowledged alerts)
                 if service.alertSummary.unacknowledgedCount > 0 {
                     AcknowledgeAllButton()
                 }
             }
 
             HStack(spacing: 20) {
-                // Total alerts
                 VStack(alignment: .leading, spacing: 4) {
                     Text("\(service.alertSummary.totalAlerts)")
                         .font(.system(.title, design: .rounded))
@@ -161,7 +229,6 @@ struct MenuView: View {
                 Divider()
                     .frame(height: 40)
 
-                // Unacknowledged
                 VStack(alignment: .leading, spacing: 4) {
                     Text("\(service.alertSummary.unacknowledgedCount)")
                         .font(.system(.title2, design: .rounded))
@@ -175,7 +242,6 @@ struct MenuView: View {
                 Divider()
                     .frame(height: 40)
 
-                // Acknowledged
                 VStack(alignment: .leading, spacing: 4) {
                     Text("\(service.alertSummary.acknowledgedCount)")
                         .font(.system(.title2, design: .rounded))
@@ -213,10 +279,12 @@ struct MenuView: View {
 
     private var footerView: some View {
         HStack {
-            Button(action: openPagerDutyWeb) {
-                Label("Open PagerDuty", systemImage: "safari")
+            if liveAccount != nil || demoAccount != nil {
+                Button(action: openDashboard) {
+                    Label(footerButtonTitle, systemImage: "safari")
+                }
+                .buttonStyle(.link)
             }
-            .buttonStyle(.link)
 
             Spacer()
 
@@ -245,10 +313,28 @@ struct MenuView: View {
 
     // MARK: - Helper Methods
 
+    private func demoScenarioBinding(for accountId: String) -> Binding<DemoScenario> {
+        Binding(
+            get: {
+                service.demoConfiguration(for: accountId)?.selectedScenario ?? .reviewOverview
+            },
+            set: { scenario in
+                service.setDemoScenario(scenario, for: accountId)
+            }
+        )
+    }
+
+    private var footerButtonTitle: String {
+        if liveAccount != nil {
+            return "Open PagerDuty"
+        }
+
+        return "Demo Guide"
+    }
+
     private func formatNextShift(_ date: Date) -> String {
         let now = Date()
         let calendar = Calendar.current
-
         let components = calendar.dateComponents([.day, .hour, .minute], from: now, to: date)
 
         if let days = components.day, days > 0 {
@@ -265,16 +351,22 @@ struct MenuView: View {
         }
     }
 
-    private func openPagerDutyWeb() {
-        if let url = URL(string: "https://app.pagerduty.com/incidents") {
-            NSWorkspace.shared.open(url)
+    private func openDashboard() {
+        let urlString: String
+        if liveAccount != nil {
+            urlString = "https://app.pagerduty.com/incidents"
+        } else {
+            urlString = "https://github.com/unicornops/oncall-notify#demo-mode"
         }
+
+        guard let url = URL(string: urlString) else {
+            return
+        }
+
+        NSWorkspace.shared.open(url)
     }
 
-    // Note: Currently supports PagerDuty, future versions will support additional services
-
     private func openSettings() {
-        // For macOS 13.0+ use modern API, fallback to legacy for macOS 12 and earlier
         if #available(macOS 13.0, *) {
             NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
         } else {
@@ -296,34 +388,32 @@ struct AcknowledgeAllButton: View {
     @State private var acknowledgmentError: String?
 
     var body: some View {
-        Button(
-            action: {
-                acknowledgeAll()
-            },
-            label: {
-                if isAcknowledging {
-                    HStack(spacing: 4) {
-                        ProgressView()
-                            .scaleEffect(0.6)
-                            .frame(width: 12, height: 12)
-                        Text("Acknowledging...")
-                            .font(.caption)
-                    }
-                } else {
-                    HStack(spacing: 4) {
-                        Image(systemName: "checkmark.circle.fill")
-                            .font(.caption)
-                        Text("Acknowledge All")
-                            .font(.caption)
-                            .fontWeight(.medium)
-                    }
+        Button {
+            acknowledgeAll()
+        } label: {
+            if isAcknowledging {
+                HStack(spacing: 4) {
+                    ProgressView()
+                        .scaleEffect(0.6)
+                        .frame(width: 12, height: 12)
+                    Text("Acknowledging...")
+                        .font(.caption)
                 }
-            })
-            .buttonStyle(.borderedProminent)
-            .controlSize(.small)
-            .tint(.orange)
-            .disabled(isAcknowledging)
-            .help("Acknowledge all unacknowledged incidents")
+            } else {
+                HStack(spacing: 4) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.caption)
+                    Text("Acknowledge All")
+                        .font(.caption)
+                        .fontWeight(.medium)
+                }
+            }
+        }
+        .buttonStyle(.borderedProminent)
+        .controlSize(.small)
+        .tint(.orange)
+        .disabled(isAcknowledging)
+        .help("Acknowledge all unacknowledged incidents")
     }
 
     private func acknowledgeAll() {
@@ -333,7 +423,6 @@ struct AcknowledgeAllButton: View {
         Task {
             do {
                 try await service.acknowledgeAllIncidents()
-                // Success - the service will refresh and update the UI
             } catch {
                 acknowledgmentError = error.localizedDescription
             }
@@ -352,20 +441,17 @@ struct IncidentRowView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             HStack(alignment: .top, spacing: 8) {
-                // Status indicator
                 Circle()
                     .fill(statusColor)
                     .frame(width: 8, height: 8)
                     .padding(.top, 4)
 
                 VStack(alignment: .leading, spacing: 4) {
-                    // Title
                     Text(incident.title)
                         .font(.subheadline)
                         .fontWeight(.medium)
                         .lineLimit(2)
 
-                    // Service and Account
                     HStack(spacing: 4) {
                         if let service = incident.service {
                             Text(service.summary)
@@ -373,7 +459,6 @@ struct IncidentRowView: View {
                                 .foregroundColor(.secondary)
                         }
 
-                        // Account badge (if available)
                         if let accountId = incident.accountId,
                            let account = getAccount(for: accountId) {
                             Text("•")
@@ -381,11 +466,10 @@ struct IncidentRowView: View {
                                 .foregroundColor(.secondary)
                             Text(account.name)
                                 .font(.caption)
-                                .foregroundColor(.blue)
+                                .foregroundColor(account.isDemoAccount ? .blue : .primary)
                         }
                     }
 
-                    // Time
                     HStack(spacing: 4) {
                         Image(systemName: "clock")
                             .font(.caption2)
@@ -394,7 +478,6 @@ struct IncidentRowView: View {
                     }
                     .foregroundColor(.secondary)
 
-                    // Error message
                     if let error = acknowledgmentError {
                         Text(error)
                             .font(.caption2)
@@ -406,40 +489,34 @@ struct IncidentRowView: View {
                 Spacer()
 
                 HStack(spacing: 8) {
-                    // Acknowledge button (only for triggered incidents)
                     if incident.status == .triggered {
-                        Button(
-                            action: {
-                                acknowledgeIncident()
-                            },
-                            label: {
-                                if isAcknowledging {
-                                    ProgressView()
-                                        .scaleEffect(0.7)
-                                        .frame(width: 16, height: 16)
-                                } else {
-                                    Image(systemName: "checkmark.circle")
-                                        .font(.caption)
-                                        .foregroundColor(.orange)
-                                }
-                            })
-                            .buttonStyle(.plain)
-                            .disabled(isAcknowledging)
-                            .help("Acknowledge incident")
+                        Button {
+                            acknowledgeIncident()
+                        } label: {
+                            if isAcknowledging {
+                                ProgressView()
+                                    .scaleEffect(0.7)
+                                    .frame(width: 16, height: 16)
+                            } else {
+                                Image(systemName: "checkmark.circle")
+                                    .font(.caption)
+                                    .foregroundColor(.orange)
+                            }
+                        }
+                        .buttonStyle(.plain)
+                        .disabled(isAcknowledging)
+                        .help("Acknowledge incident")
                     }
 
-                    // Open button
                     if let urlString = incident.htmlUrl,
                        let url = URL(string: urlString) {
-                        Button(
-                            action: {
-                                NSWorkspace.shared.open(url)
-                            },
-                            label: {
-                                Image(systemName: "arrow.up.right.square")
-                                    .font(.caption)
-                            })
-                            .buttonStyle(.plain)
+                        Button {
+                            NSWorkspace.shared.open(url)
+                        } label: {
+                            Image(systemName: "arrow.up.right.square")
+                                .font(.caption)
+                        }
+                        .buttonStyle(.plain)
                     }
                 }
             }
@@ -464,7 +541,6 @@ struct IncidentRowView: View {
     }
 
     private func acknowledgeIncident() {
-        // Make sure we have an account ID
         guard let accountId = incident.accountId else {
             acknowledgmentError = "Unable to identify account for this incident"
             return
@@ -479,7 +555,6 @@ struct IncidentRowView: View {
                     incidentId: incident.id,
                     accountId: accountId
                 )
-                // Success - the service will refresh and update the UI
             } catch {
                 acknowledgmentError = error.localizedDescription
             }

--- a/OnCallNotify/Views/SettingsView.swift
+++ b/OnCallNotify/Views/SettingsView.swift
@@ -11,75 +11,22 @@ struct SettingsView: View {
     @State private var accounts: [Account] = []
     @State private var showingAddAccount = false
     @State private var accountToEdit: Account?
-    @State private var showError: Bool = false
-    @State private var errorMessage: String = ""
+    @State private var showError = false
+    @State private var errorMessage = ""
+
+    private var demoAccounts: [Account] {
+        accounts.filter { $0.isDemoAccount }
+    }
 
     var body: some View {
         VStack(spacing: 0) {
             Form {
-                Section {
-                    VStack(alignment: .leading, spacing: 12) {
-                        if accounts.isEmpty {
-                            HStack {
-                                Image(systemName: "info.circle")
-                                    .foregroundColor(.blue)
-                                Text("No accounts configured. Add an account to get started.")
-                                    .font(.subheadline)
-                                    .foregroundColor(.secondary)
-                            }
-                            .padding(.vertical, 8)
-                        } else {
-                            ForEach(accounts) { account in
-                                AccountRowView(
-                                    account: account,
-                                    onEdit: { editAccount(account) },
-                                    onDelete: { deleteAccount(account) },
-                                    onToggle: { toggleAccount(account) }
-                                )
-                            }
-                        }
-
-                        Button {
-                            showingAddAccount = true
-                        } label: {
-                            Label("Add Account", systemImage: "plus.circle")
-                        }
-                    }
-                    .padding(.vertical, 8)
-                } header: {
-                    Text("Accounts")
-                }
-
-                Section {
-                    VStack(alignment: .leading, spacing: 8) {
-                        HStack {
-                            Text("Auto-refresh:")
-                            Spacer()
-                            Text("Every 60 seconds")
-                                .foregroundColor(.secondary)
-                        }
-
-                        HStack {
-                            Text("Data Storage:")
-                            Spacer()
-                            Text("Keychain (Secure)")
-                                .foregroundColor(.secondary)
-                        }
-
-                        HStack {
-                            Text("Active Accounts:")
-                            Spacer()
-                            Text("\(accounts.filter { $0.isEnabled }.count) of \(accounts.count)")
-                                .foregroundColor(.secondary)
-                        }
-                    }
-                    .padding(.vertical, 8)
-                } header: {
-                    Text("Information")
-                }
+                demoModeSection
+                accountsSection
+                informationSection
             }
             .formStyle(.grouped)
-            .frame(minWidth: 600, minHeight: 400)
+            .frame(minWidth: 640, minHeight: 440)
 
             if showError {
                 HStack {
@@ -98,12 +45,15 @@ struct SettingsView: View {
             }
         }
         .sheet(isPresented: $showingAddAccount) {
-            AddAccountView(onSave: { account, token in
-                addAccount(account, token: token)
-                showingAddAccount = false
-            }, onCancel: {
-                showingAddAccount = false
-            })
+            AddAccountView(
+                onSave: { account, token in
+                    addAccount(account, token: token)
+                    showingAddAccount = false
+                },
+                onCancel: {
+                    showingAddAccount = false
+                }
+            )
         }
         .sheet(item: $accountToEdit) { account in
             EditAccountView(
@@ -119,6 +69,111 @@ struct SettingsView: View {
         }
         .onAppear {
             loadAccounts()
+        }
+    }
+
+    private var demoModeSection: some View {
+        Section {
+            VStack(alignment: .leading, spacing: 12) {
+                Label("Review-Friendly Demo Mode", systemImage: "play.square.fill")
+                    .font(.headline)
+
+                Text(
+                    "Demo Mode runs entirely offline with local sample incidents, on-call state, " +
+                        "and acknowledge actions. It is intended for App Store review " +
+                        "and for anyone evaluating the app without a paid PagerDuty account."
+                )
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+                if demoAccounts.isEmpty {
+                    Button {
+                        addDemoAccount()
+                    } label: {
+                        Label("Add Demo Account", systemImage: "plus.circle.fill")
+                    }
+                } else {
+                    ForEach(demoAccounts) { account in
+                        DemoAccountControlsView(account: account)
+                    }
+                }
+            }
+            .padding(.vertical, 8)
+        } header: {
+            Text("Demo Mode")
+        }
+    }
+
+    private var accountsSection: some View {
+        Section {
+            VStack(alignment: .leading, spacing: 12) {
+                if accounts.isEmpty {
+                    HStack {
+                        Image(systemName: "info.circle")
+                            .foregroundColor(.blue)
+                        Text("No accounts configured. Add a PagerDuty account or create a Demo account to get started.")
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+                    }
+                    .padding(.vertical, 8)
+                } else {
+                    ForEach(accounts) { account in
+                        AccountRowView(
+                            account: account,
+                            onEdit: { editAccount(account) },
+                            onDelete: { deleteAccount(account) },
+                            onToggle: { toggleAccount(account) }
+                        )
+                    }
+                }
+
+                Button {
+                    showingAddAccount = true
+                } label: {
+                    Label("Add Account", systemImage: "plus.circle")
+                }
+            }
+            .padding(.vertical, 8)
+        } header: {
+            Text("Accounts")
+        }
+    }
+
+    private var informationSection: some View {
+        Section {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Text("Auto-refresh:")
+                    Spacer()
+                    Text("Every 60 seconds")
+                        .foregroundColor(.secondary)
+                }
+
+                HStack {
+                    Text("Data Storage:")
+                    Spacer()
+                    Text("Keychain + UserDefaults")
+                        .foregroundColor(.secondary)
+                }
+
+                HStack {
+                    Text("Active Accounts:")
+                    Spacer()
+                    Text("\(accounts.filter { $0.isEnabled }.count) of \(accounts.count)")
+                        .foregroundColor(.secondary)
+                }
+
+                HStack {
+                    Text("App Review Access:")
+                    Spacer()
+                    Text(demoAccounts.isEmpty ? "Add Demo Mode" : "Ready")
+                        .foregroundColor(demoAccounts.isEmpty ? .orange : .green)
+                }
+            }
+            .padding(.vertical, 8)
+        } header: {
+            Text("Information")
         }
     }
 
@@ -140,17 +195,23 @@ struct SettingsView: View {
         }
     }
 
+    private func addDemoAccount() {
+        let demoAccount = Account(name: "Demo Workspace", serviceType: .demo, isEnabled: true)
+        addAccount(demoAccount, token: "")
+    }
+
     private func editAccount(_ account: Account) {
         accountToEdit = account
     }
 
     private func updateAccount(_ account: Account, newToken: String?) {
-        // Update account metadata
         var success = KeychainHelper.shared.updateAccount(account)
 
-        // If a new token was provided, update it
-        if success, let token = newToken, !token.isEmpty {
-            success = KeychainHelper.shared.updateAPIToken(for: account.id, token: token)
+        if success,
+           account.requiresAPIToken,
+           let newToken,
+           !newToken.isEmpty {
+            success = KeychainHelper.shared.updateAPIToken(for: account.id, token: newToken)
         }
 
         if success {
@@ -190,6 +251,75 @@ struct SettingsView: View {
     }
 }
 
+// MARK: - Demo Controls
+
+struct DemoAccountControlsView: View {
+    let account: Account
+    @ObservedObject private var service = OnCallService.shared
+
+    private var scenarioBinding: Binding<DemoScenario> {
+        Binding(
+            get: {
+                service.demoConfiguration(for: account.id)?.selectedScenario ?? .reviewOverview
+            },
+            set: { scenario in
+                service.setDemoScenario(scenario, for: account.id)
+            }
+        )
+    }
+
+    private var selectedScenario: DemoScenario {
+        service.demoConfiguration(for: account.id)?.selectedScenario ?? .reviewOverview
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(account.name)
+                        .font(.headline)
+                    Text("No sign-in required. All demo actions stay local on this Mac.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+
+                Spacer()
+
+                Button {
+                    service.resetDemoScenario(for: account.id)
+                } label: {
+                    Label("Reset", systemImage: "arrow.counterclockwise")
+                }
+                .buttonStyle(.bordered)
+
+                Button {
+                    service.advanceDemoScenario(for: account.id)
+                } label: {
+                    Label("Next Scenario", systemImage: "arrow.right.circle")
+                }
+                .buttonStyle(.borderedProminent)
+            }
+
+            Picker("Demo Scenario", selection: scenarioBinding) {
+                ForEach(DemoScenario.allCases) { scenario in
+                    Text(scenario.displayName).tag(scenario)
+                }
+            }
+            .pickerStyle(.menu)
+
+            Text(selectedScenario.description)
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(Color.blue.opacity(0.06))
+        )
+    }
+}
+
 // MARK: - Account Row View
 
 struct AccountRowView: View {
@@ -198,12 +328,11 @@ struct AccountRowView: View {
     let onDelete: () -> Void
     let onToggle: () -> Void
 
-    @State private var isTestingConnection: Bool = false
+    @State private var isTestingConnection = false
     @State private var connectionTestResult: Bool?
 
     var body: some View {
         HStack(alignment: .center, spacing: 12) {
-            // Service icon
             Image(systemName: serviceIcon)
                 .font(.title2)
                 .foregroundColor(account.isEnabled ? .blue : .gray)
@@ -218,7 +347,11 @@ struct AccountRowView: View {
                     .font(.caption)
                     .foregroundColor(.secondary)
 
-                if !account.isEnabled {
+                if account.isDemoAccount {
+                    Text("Offline sample data for App Review and evaluation")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                } else if !account.isEnabled {
                     Text("Disabled")
                         .font(.caption)
                         .foregroundColor(.orange)
@@ -227,7 +360,6 @@ struct AccountRowView: View {
 
             Spacer()
 
-            // Test Connection button
             Button(action: testConnection) {
                 if isTestingConnection {
                     ProgressView()
@@ -236,14 +368,13 @@ struct AccountRowView: View {
                     Image(systemName: result ? "checkmark.circle.fill" : "xmark.circle.fill")
                         .foregroundColor(result ? .green : .red)
                 } else {
-                    Image(systemName: "network")
+                    Image(systemName: account.isDemoAccount ? "play.circle" : "network")
                 }
             }
             .buttonStyle(.plain)
             .disabled(isTestingConnection || !account.isEnabled)
-            .help("Test Connection")
+            .help(account.isDemoAccount ? "Validate Demo Mode" : "Test Connection")
 
-            // Toggle enabled
             Button(action: onToggle) {
                 Image(systemName: account.isEnabled ? "checkmark.circle.fill" : "circle")
                     .foregroundColor(account.isEnabled ? .green : .gray)
@@ -251,7 +382,6 @@ struct AccountRowView: View {
             .buttonStyle(.plain)
             .help(account.isEnabled ? "Disable Account" : "Enable Account")
 
-            // Edit button
             Button(action: onEdit) {
                 Image(systemName: "pencil")
                     .foregroundColor(.blue)
@@ -259,7 +389,6 @@ struct AccountRowView: View {
             .buttonStyle(.plain)
             .help("Edit Account")
 
-            // Delete button
             Button(action: onDelete) {
                 Image(systemName: "trash")
                     .foregroundColor(.red)
@@ -277,6 +406,8 @@ struct AccountRowView: View {
 
     private var serviceIcon: String {
         switch account.serviceType {
+        case .demo:
+            "play.square.fill"
         case .pagerDuty:
             "bell.fill"
         }
@@ -303,15 +434,14 @@ struct AddAccountView: View {
     let onSave: (Account, String) -> Void
     let onCancel: () -> Void
 
-    @State private var accountName: String = ""
-    @State private var serviceType: ServiceType = .pagerDuty
-    @State private var apiToken: String = ""
-    @State private var showError: Bool = false
-    @State private var errorMessage: String = ""
+    @State private var accountName = ""
+    @State private var serviceType: ServiceType = .demo
+    @State private var apiToken = ""
+    @State private var showError = false
+    @State private var errorMessage = ""
 
     var body: some View {
         VStack(spacing: 0) {
-            // Header
             HStack {
                 Text("Add New Account")
                     .font(.title2)
@@ -322,7 +452,6 @@ struct AddAccountView: View {
 
             Divider()
 
-            // Form
             Form {
                 Section {
                     TextField("Account Name", text: $accountName)
@@ -334,8 +463,18 @@ struct AddAccountView: View {
                         }
                     }
 
-                    SecureField("API Token", text: $apiToken)
-                        .textFieldStyle(.roundedBorder)
+                    if serviceType.requiresAPIToken {
+                        SecureField("API Token", text: $apiToken)
+                            .textFieldStyle(.roundedBorder)
+                    } else {
+                        HStack(spacing: 8) {
+                            Image(systemName: "checkmark.shield")
+                                .foregroundColor(.green)
+                            Text("Demo Mode does not require credentials.")
+                                .font(.subheadline)
+                                .foregroundColor(.secondary)
+                        }
+                    }
 
                     Text(serviceInstructions)
                         .font(.caption)
@@ -362,7 +501,6 @@ struct AddAccountView: View {
 
             Divider()
 
-            // Footer buttons
             HStack {
                 Button("Cancel", action: onCancel)
                     .keyboardShortcut(.cancelAction)
@@ -373,22 +511,28 @@ struct AddAccountView: View {
                     saveAccount()
                 }
                 .keyboardShortcut(.defaultAction)
-                .disabled(accountName.isEmpty || apiToken.isEmpty)
+                .disabled(accountName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || addButtonDisabled)
             }
             .padding()
         }
-        .frame(width: 500, height: 400)
+        .frame(width: 520, height: 400)
+    }
+
+    private var addButtonDisabled: Bool {
+        serviceType.requiresAPIToken && apiToken.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
     private var serviceInstructions: String {
         switch serviceType {
+        case .demo:
+            "Demo Mode creates local sample incidents and on-call data " +
+                "so the full app can be explored without external sign-in."
         case .pagerDuty:
             "Create an API token in your PagerDuty account under User Settings → API Access Keys."
         }
     }
 
     private func saveAccount() {
-        // Validate inputs
         let trimmedName = accountName.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedToken = apiToken.trimmingCharacters(in: .whitespacesAndNewlines)
 
@@ -398,142 +542,7 @@ struct AddAccountView: View {
             return
         }
 
-        let validation = validateAPIToken(trimmedToken)
-        guard validation.isValid else {
-            showError = true
-            errorMessage = validation.message ?? "Invalid API token"
-            return
-        }
-
-        // Create account
-        let account = Account(
-            name: trimmedName,
-            serviceType: serviceType,
-            isEnabled: true
-        )
-
-        onSave(account, trimmedToken)
-    }
-
-    private func validateAPIToken(_ token: String) -> (isValid: Bool, message: String?) {
-        let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
-
-        guard trimmed.count >= 20 else {
-            return (false, "API token must be at least 20 characters")
-        }
-
-        guard trimmed.count <= 100 else {
-            return (false, "API token appears to be invalid (too long)")
-        }
-
-        let allowedCharacters = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_+"))
-        guard trimmed.rangeOfCharacter(from: allowedCharacters.inverted) == nil else {
-            return (false, "API token contains invalid characters")
-        }
-
-        return (true, nil)
-    }
-}
-
-// MARK: - Edit Account View
-
-struct EditAccountView: View {
-    let account: Account
-    let onSave: (Account, String?) -> Void
-    let onCancel: () -> Void
-
-    @State private var accountName: String = ""
-    @State private var apiToken: String = ""
-    @State private var showError: Bool = false
-    @State private var errorMessage: String = ""
-
-    var body: some View {
-        VStack(spacing: 0) {
-            // Header
-            HStack {
-                Text("Edit Account")
-                    .font(.title2)
-                    .fontWeight(.semibold)
-                Spacer()
-            }
-            .padding()
-
-            Divider()
-
-            // Form
-            Form {
-                Section {
-                    TextField("Account Name", text: $accountName)
-                        .textFieldStyle(.roundedBorder)
-
-                    HStack {
-                        Text("Service Type:")
-                        Spacer()
-                        Text(account.serviceType.displayName)
-                            .foregroundColor(.secondary)
-                    }
-
-                    SecureField("New API Token (leave blank to keep current)", text: $apiToken)
-                        .textFieldStyle(.roundedBorder)
-
-                    Text("Leave the API token field empty to keep the existing token.")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                } header: {
-                    Text("Account Details")
-                }
-            }
-            .formStyle(.grouped)
-            .padding()
-
-            if showError {
-                HStack {
-                    Image(systemName: "exclamationmark.triangle.fill")
-                        .foregroundColor(.orange)
-                    Text(errorMessage)
-                        .font(.caption)
-                    Spacer()
-                }
-                .padding()
-                .background(Color.orange.opacity(0.1))
-            }
-
-            Divider()
-
-            // Footer buttons
-            HStack {
-                Button("Cancel", action: onCancel)
-                    .keyboardShortcut(.cancelAction)
-
-                Spacer()
-
-                Button("Save Changes") {
-                    saveChanges()
-                }
-                .keyboardShortcut(.defaultAction)
-                .disabled(accountName.isEmpty)
-            }
-            .padding()
-        }
-        .frame(width: 500, height: 350)
-        .onAppear {
-            accountName = account.name
-        }
-    }
-
-    private func saveChanges() {
-        let trimmedName = accountName.trimmingCharacters(in: .whitespacesAndNewlines)
-        let trimmedToken = apiToken.trimmingCharacters(in: .whitespacesAndNewlines)
-
-        guard !trimmedName.isEmpty else {
-            showError = true
-            errorMessage = "Please enter an account name"
-            return
-        }
-
-        // Only validate token if one was provided
-        if !trimmedToken.isEmpty {
+        if serviceType.requiresAPIToken {
             let validation = validateAPIToken(trimmedToken)
             guard validation.isValid else {
                 showError = true
@@ -542,12 +551,13 @@ struct EditAccountView: View {
             }
         }
 
-        // Create updated account
-        var updatedAccount = account
-        updatedAccount.name = trimmedName
+        let account = Account(
+            name: trimmedName,
+            serviceType: serviceType,
+            isEnabled: true
+        )
 
-        // Pass nil for token if not changed, otherwise pass the new token
-        onSave(updatedAccount, trimmedToken.isEmpty ? nil : trimmedToken)
+        onSave(account, trimmedToken)
     }
 
     private func validateAPIToken(_ token: String) -> (isValid: Bool, message: String?) {

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ plans to add support for additional on-call and incident management platforms in
 - 👤 **On-Call Status**: Visual indicator showing if you're currently on-call
 - 📅 **Next Shift Information**: See when your next on-call shift starts
 - 🔐 **Multi-Account Support**: Monitor multiple accounts across services simultaneously
+- ▶️ **Full Demo Mode**: Explore the app without PagerDuty credentials or a paid account
 - 🔒 **Secure Storage**: API tokens stored securely in macOS Keychain
 - 🔄 **Auto-refresh**: Automatically updates every 60 seconds
 - 🎨 **Native macOS UI**: Built with SwiftUI for a native look and feel
@@ -31,6 +32,7 @@ plans to add support for additional on-call and incident management platforms in
 
 ### Currently Supported
 
+- ✅ **Demo Mode** - Full local walkthrough for App Store review and evaluation
 - ✅ **PagerDuty** - Full support for incidents and on-call schedules
 
 ### Coming Soon
@@ -81,7 +83,7 @@ Manage your accounts with:
 
 - macOS 13.0 (Ventura) or later
 - Xcode 15.0 or later (for building)
-- Account with a supported service (currently PagerDuty)
+- Optional: PagerDuty account and API token for live data
 
 ## Installation
 
@@ -127,15 +129,40 @@ Pre-built releases will be available in the GitHub Releases section.
 1. Launch OnCall Notify (it will appear in your menu bar)
 2. Click the menu bar icon
 3. Click the gear icon (⚙️) to open Settings
-4. Click "Add Account" to add your first account
+4. Use the seeded **App Store Demo** account for an immediate walkthrough, or click "Add Account"
 5. Enter a friendly name for the account (e.g., "Work PagerDuty")
-6. Select the service type (currently only PagerDuty is supported)
-7. Paste your API token
+6. Select the service type (`Demo Mode` or `PagerDuty`)
+7. If you selected PagerDuty, paste your API token
 8. Click "Add Account"
 9. Test the connection using the network icon
 10. Add additional accounts as needed by repeating steps 4-9
 
 The app will now automatically fetch and display your alerts and on-call status from all enabled accounts.
+
+## Demo Mode
+
+On first launch, OnCall Notify creates a default **App Store Demo** account so the app is usable without
+external credentials. Demo Mode is intended for:
+
+- App Store review
+- Product evaluation before connecting PagerDuty
+- UI and notification testing without touching a live incident system
+
+Demo Mode includes:
+
+- Local sample incidents with triggered and acknowledged states
+- On-call and next-shift examples
+- Working acknowledge actions
+- Scenario switching from both the menu bar popover and Settings
+- No network sign-in requirement
+
+### App Review Flow
+
+1. Launch the app and click the menu bar icon.
+2. Verify the seeded **App Store Demo** account loads automatically.
+3. Use the **Demo Mode** section in the popover to switch scenarios.
+4. Review active alerts, on-call state, next shift, and acknowledge actions.
+5. Open **Settings** to confirm demo mode is available without credentials.
 
 ### Managing Multiple Accounts
 


### PR DESCRIPTION
- Introduce Demo Mode as a selectable service type
- Add demo scenarios for App Store review and local walkthroughs
- Seed a default demo account if none exists
- Update UI to surface demo mode in MenuView and SettingsView
- Demo mode requires no credentials and enables credential-free
  exploration
- Update changelog and documentation to reflect demo mode availability
